### PR TITLE
improved SQL connection error logging + updated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ It runs the files in alphabetical order.
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 
 ## Release History
+- v0.2.2 - fixed README example, improved connection error logging, cleaned up dependencies
 - v0.2.1 - Added README, fixed some minor bugs and added to wercker ci
 - v0.2.0 - Bug fix for running add unix environments.
 - v0.1.0 - Initial release.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ grunt.initConfig({
 		options: {
 			connection: {
 				host: 'example.com',
-				username: 'exampleuser',
+				user: 'exampleuser',
 				password: 'examplepassword',
 				database: 'exampledatabase',
 				multipleStatements: true

--- a/package.json
+++ b/package.json
@@ -26,17 +26,17 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "glob": "~4.3.1",
-    "grunt": "~0.4.5",
-    "lodash": "~2.4.1",
-    "mysql": "~2.3.2",
-    "q": "~1.1.2",
-    "wrench": "~1.5.8"
+    "glob": "^4.3.1",
+    "lodash": "^2.4.1",
+    "mysql": "^2.3.2",
+    "q": "^1.1.2"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-contrib-clean": "~0.6.0",
-    "grunt-contrib-jshint": "~0.10.0"
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-jshint": "^0.10.0"
+  },
+  "peerDependencies": {
+    "grunt": "^0.4.5"
   },
   "keywords": [
     "mysql",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-mysql-runfile",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Runs the given sql files on the mysql database.",
   "homepage": "https://github.com/Hiiragisan09/grunt-mysql-runfile",
   "author": {

--- a/tasks/lib/mysql.js
+++ b/tasks/lib/mysql.js
@@ -19,7 +19,7 @@ exports.init = function(grunt, options)
 
 		connection.connect(function(err) {
 			if (err) {
-				grunt.fatal('Unable to connect to database server: ', err);
+				grunt.fatal('Unable to connect to database server: ' + err);
 
 				deferred.reject();
 				return;


### PR DESCRIPTION
Hi,

Thanks a lot for sharing grunt-mysql-runfile, it's exactly what I needed to load my test database.

Unfortunately I had some trouble to get it working because:
- the README mentioned an option `username` while node-mysql actually needs `user`
- the error logging did not display the details of the error

So I fixed both and cleaned the package.json to fix `npm install` warnings.
